### PR TITLE
fix -5999 error when upload file

### DIFF
--- a/src/Client/Cosapi.php
+++ b/src/Client/Cosapi.php
@@ -61,6 +61,8 @@ class Cosapi
                     'message' => 'file '.$srcPath.' not exists',
                     'data'    => [], ];
         }
+        
+        $dstPath = '/'.ltrim($dstPath, '/');
 
         //文件大于20M则使用分片传输
         if (filesize($srcPath) < self::MAX_UNSLICE_FILE_SIZE) {


### PR DESCRIPTION
当传入的目标地址参数不以 '/' 开头时，如果不补齐 '/' 则会出现 -5999 错误。