### PR TITLE
fix undefined index $ret['data']['session']

### DIFF
--- a/src/Client/Cosapi.php
+++ b/src/Client/Cosapi.php
@@ -535,7 +535,7 @@ class Cosapi
                 return $ret;
             }
 
-            if ($ret['data']['session']) {
+            if (!empty($ret['data']['session'])) {
                 $session = $ret['data']['session'];
             }
 


### PR DESCRIPTION
WTF! Weird `undefined index $ret['data']['session']` error occured today.

鹅厂的sdk和接口简直烂到爆。。。